### PR TITLE
generate_suite: escape the suite name in filename

### DIFF
--- a/lib/minitest/ci.rb
+++ b/lib/minitest/ci.rb
@@ -1,4 +1,5 @@
 require 'minitest/unit'
+require 'cgi'
 #unless MiniTest::Unit::VERSION >= '2.12.0'
 unless MiniTest::Unit.public_method_defined? :record
   abort 'you are running an unsupported version of MiniTest. try upgrading.'
@@ -68,7 +69,7 @@ module MiniTest
         end
       end
 
-      File.open "TEST-#{name}.xml", "w" do |f|
+      File.open "TEST-#{CGI.escape(name.to_s)}.xml", "w" do |f|
         f.puts '<?xml version="1.0" encoding="UTF-8"?>'
         f.puts "<testsuite time='#{"%6f" % total_time}' skipped='#{skips}' failures='#{failures}' errors='#{errors}' name='#{name}' assertions='#{assertions}' tests='#{suite.count}'>"
 

--- a/test/test_minitest_ci.rb
+++ b/test/test_minitest_ci.rb
@@ -1,4 +1,5 @@
 require "minitest/ci"
+require "minitest/spec"
 require "minitest/autorun"
 require 'stringio'
 require 'nokogiri'
@@ -33,6 +34,12 @@ class MockTestSuite < MiniTest::Unit::TestCase
   end
 end
 
+SpecWithPunctuation = describe "spec/with::punctuation" do
+ it "passes" do
+   pass
+ end
+end
+
 class TestMinitest
 end
 
@@ -43,6 +50,7 @@ class TestMinitest::TestCi < MiniTest::Unit::TestCase
     runner = MiniTest::CiUnit.new
 
     runner._run_suite MockTestSuite, :test
+    runner._run_suite SpecWithPunctuation, :test
 
     @@test_suites.delete MockTestSuite
     MiniTest::Ci.finish runner.output
@@ -115,5 +123,10 @@ class TestMinitest::TestCi < MiniTest::Unit::TestCase
   def test_filtering_backtraces
     error = @doc.at_xpath('/testsuite/testcase[@name="test_raise_error"]')
     refute_match( /lib\/minitest/, error.inner_text )
+  end
+
+  def test_testname
+    assert File.file?(File.join(MiniTest::Ci.report_dir,
+                      "TEST-spec%2Fwith%3A%3Apunctuation.xml"))
   end
 end


### PR DESCRIPTION
I've started to write view tests with MiniTest::Spec whose names contain slashes. This breaks MiniTest::Ci as it currently just uses the raw name of the test suite as part of the filenames it generates. When this name contains a "/", the part before it is interpreted as the name of a directory. Which does not exist and is not meant to.

As a simple fix, please CGI.escape the name of the suite.
