### PR TITLE
Fix problems preventing ci_setup task from running

### DIFF
--- a/lib/minitest/ci.rb
+++ b/lib/minitest/ci.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'cgi'
+require 'minitest'
 
 module Minitest
   class Ci < Reporter


### PR DESCRIPTION
I just tried to setup Minitest::Ci according to the directions in the README, however I ran into a couple of issues:
- Minitest::Reporter was not defined if I only required "minitest/ci"; so I made "minitest/ci.rb" require "minitest"
- Minitest::Ci expected to have an attribute named "results", which it may have inherited from an earlier version of Minitest, but does not exist in Minitest::Reporter for minitest 5.0.6
