### PR TITLE
Support double quotes in suite and spec names

### DIFF
--- a/lib/minitest/ci.rb
+++ b/lib/minitest/ci.rb
@@ -84,12 +84,12 @@ module Minitest
       xml = []
 
       xml << '<?xml version="1.0" encoding="UTF-8"?>'
-      xml << "<testsuite time='%6f' skipped='%d' failures='%d' errors='%d' name=%p assertions='%d' tests='%d'>" %
-        [total_time, skips, failures, errors, name.to_s, assertions, results.count]
+      xml << "<testsuite time='%6f' skipped='%d' failures='%d' errors='%d' name='%s' assertions='%d' tests='%d'>" %
+        [total_time, skips, failures, errors, escape(name), assertions, results.count]
 
       results.each do |result|
-        xml << "  <testcase time='%6f' name=%p assertions='%s'>" %
-          [result.time, result.name, result.assertions]
+        xml << "  <testcase time='%6f' name='%s' assertions='%s'>" %
+          [result.time, escape(result.name), result.assertions]
         if failure = result.failure
           label = failure.result_label.downcase
 

--- a/test/minitest/test_ci.rb
+++ b/test/minitest/test_ci.rb
@@ -41,6 +41,12 @@ SpecWithPunctuation = describe "spec/with::'punctuation'" do
  end
 end
 
+SpecWithDoubleQuote = describe 'spec/with::"doublequotes"' do
+ it 'will "pass"' do
+   pass
+ end
+end
+
 # better way?
 $ci_io = StringIO.new
 Minitest::Ci.clean = false
@@ -142,5 +148,18 @@ class TestMinitest::TestCi < Minitest::Test
     file = File.read "test/reports/TEST-spec%2Fwith%3A%3A%27punctuation%27.xml"
     suite = Nokogiri.parse(file).at_xpath('/testsuite')
     assert_equal "spec/with::'punctuation'", suite['name']
+  end
+
+  def test_suitename_with_double_quotes
+    file = File.read "test/reports/TEST-spec%2Fwith%3A%3A%22doublequotes%22.xml"
+    suite = Nokogiri.parse(file).at_xpath('/testsuite')
+    assert_equal 'spec/with::"doublequotes"', suite['name']
+  end
+
+  def test_testcase_name_with_double_quotes
+    file = File.read "test/reports/TEST-spec%2Fwith%3A%3A%22doublequotes%22.xml"
+
+    testcase = Nokogiri.parse(file).at_xpath('/testsuite/testcase')
+    assert_equal 'test_0001_will "pass"', testcase['name']
   end
 end


### PR DESCRIPTION
HTML escape suite names and spec descriptions so double quotes don't
break the xml output and instead are written as `&quot;`.

Consider the string `'foo "bar" baz'`
Relying on `#inspect` gives a result of `"foo \"bar\" baz"`, a backslash escape doesn't work in xml
Escaping will return `foo &quot;bar&quot; baz` which parses correctly
